### PR TITLE
Change color lightness algorithm to match GitHub exactly

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const {parse} = require('url');
 
 const opentype = require('opentype.js');
 const layer = require('color-composite');
-const isDark = require('color-measure/is-dark');
 
 // rgba(27,31,35,0.12)
 const BOX_SHADOW = {
@@ -32,7 +31,7 @@ const server = http.createServer((req, res) => {
           calcWidth(text),
           stringifyHex(rgb),
           calcShadow(rgb),
-          isDarkColor(rgb) ? '#fff' : '#000'
+          isLightColor(rgb) ? '#000' : '#fff'
         )
       );
     }
@@ -68,13 +67,13 @@ function hexToRGB(hex) {
   };
 }
 
-function isDarkColor(rgb) {
-  const [r, g, b] = rgb.values;
-  return isDark({
-    red: () => r,
-    green: () => g,
-    blue: () => b
-  });
+// http://24ways.org/2010/calculating-color-contrast
+// This is the same lightness algorithm as used on GitHub
+function isLightColor(color) {
+  const [r, g, b] = color.values;
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  // Note: the value 150 is hardcoded into GitHub
+  return yiq > 150;
 }
 
 function stringifyHex(color) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,6 @@
       "resolved": "https://registry.npmjs.org/color-composite/-/color-composite-0.1.0.tgz",
       "integrity": "sha1-3eINWUfYFBf4QrUXJsT+3h7RS64="
     },
-    "color-measure": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/color-measure/-/color-measure-1.0.1.tgz",
-      "integrity": "sha1-zmLQnp5V4MWZSupNTzZaGmus/8Q="
-    },
     "opentype.js": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "color-composite": "^0.1.0",
-    "color-measure": "^1.0.1",
     "opentype.js": "^0.7.3"
   },
   "license": "MIT"


### PR DESCRIPTION
GitHub uses a different cutoff for light/dark than the `color-measure/is-dark`. This PR makes it the same.